### PR TITLE
ci: Add an Ubuntu:22.04 builder for RISC-V

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,3 +93,26 @@ jobs:
         working-directory: ${{ github.workspace }}
         env:
           ANDROID_NDK: ${{ steps.setup-ndk.outputs.ndk-path }}
+  cmake-linux-qemu:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 40
+    strategy:
+      matrix:
+        build_props:
+          - [
+              "cmake-linux-riscv64",
+              "riscv64/ubuntu:22.04"
+          ]
+
+    name: ${{ matrix.build_props[0] }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3.0.0
+      - name: Build cpuinfo in ${{ matrix.build_props[1] }}
+        run: |
+          docker run -i -v $(pwd):/cpuinfo ${{ matrix.build_props[1] }} /bin/bash -c "
+          apt update &&
+          apt install -y cmake git gcc g++ &&
+          cd /cpuinfo &&
+          scripts/local-build.sh"


### PR DESCRIPTION
cpuinfo is built for riscv64 using a riscv64 container.  binfmt_misc allows the riscv64 binaries in the container to be executed with QEMU. This is slower than cross compiling but as there's not that much code the build times are acceptable.  It takes just under 6 minutes for the full riscv64 github action to run.  We also have the option of running some of the built RISC-V binaries, e.g., unit tests, in the CI. It should be easy to expand the matrix to add CI for other architectures not natively supported by github actions.